### PR TITLE
Add footer links to the rails template

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -18,6 +18,23 @@
         display: none;
     }
 
+    .panel .footer {
+      width: 100%;
+      height: 29px;
+      position: absolute;
+      bottom: 0;
+      border-top: 1px solid #666;
+      z-index: 99;
+      background: #fff;
+    }
+
+    .panel .footer p {
+      margin-top: 9px;
+      text-align: center;
+      font-size: 13px;
+    }
+
+
     /* Header with search box (begin) */
         .panel .header
         {
@@ -255,6 +272,7 @@
             -overflow-y: hidden;
             background: #EEE url(../i/tree_bg.png);
             z-index: 30;
+            margin-bottom: 30px;
         }
 
         .panel .tree ul

--- a/lib/rdoc/generator/template/rails/resources/panel/index.html
+++ b/lib/rdoc/generator/template/rails/resources/panel/index.html
@@ -71,6 +71,17 @@
       <ul>
       </ul>
     </div>
+    <div class="footer">
+      <p>
+        Versions:
+        <a href="http://api.rubyonrails.org/v4.2/">v4.2</a> ⎯
+        <a href="http://api.rubyonrails.org/v4.1/">v4.1</a> ⎯
+        <a href="http://api.rubyonrails.org/v4.0/">v4.0</a> ⎯
+        <a href="http://api.rubyonrails.org/v3.1/">v3.1</a> ⎯
+        <a href="http://api.rubyonrails.org/v3.0/">v3.0</a> ⎯
+        <a href="http://api.rubyonrails.org/v2.3/">v2.3</a>
+      </p>
+    </div>
   </div>
   <a href="links.html" id="links">index</a>
 </body>

--- a/lib/rdoc/generator/template/rails/resources/panel/index.html
+++ b/lib/rdoc/generator/template/rails/resources/panel/index.html
@@ -77,8 +77,8 @@
         <a href="http://api.rubyonrails.org/v4.2/">v4.2</a> ⎯
         <a href="http://api.rubyonrails.org/v4.1/">v4.1</a> ⎯
         <a href="http://api.rubyonrails.org/v4.0/">v4.0</a> ⎯
+        <a href="http://api.rubyonrails.org/v3.2/">v3.2</a> ⎯
         <a href="http://api.rubyonrails.org/v3.1/">v3.1</a> ⎯
-        <a href="http://api.rubyonrails.org/v3.0/">v3.0</a> ⎯
         <a href="http://api.rubyonrails.org/v2.3/">v2.3</a>
       </p>
     </div>


### PR DESCRIPTION
This adds several hardcoded links to old versions of existing published Rails docs to the Rails doc template. They're placed down in the footer of the left hand side panel. I'm confident that it's difficult to find links to these online (just google for "Rails 4 docs"), and this should help others find it from the official source.

<img width="769" alt="screen shot 2016-08-08 at 11 39 46 pm" src="https://cloud.githubusercontent.com/assets/12610/17503983/bcf718c6-5dc2-11e6-88bd-5da1e2ea3d7c.png">

I think the Rails versions change somewhat infrequently - so updating these footer links as major versions come out shouldn't be a huge hassle. I'll leave it to the Rails team to decide just what versions should be included in here.

Looping in a few from our Campfire discussion today. cc @fxn @eileencodes @matthewd
