### PR TITLE
Removed needless json dependency and drop to support Ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 before_install:
   - gem install bundler
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
@@ -15,7 +14,6 @@ matrix:
   allow_failures:
     - env: rdoc=master
   include:
-    - { rvm: 1.8.7, env: rdoc=master }
     - { rvm: 1.9.3, env: rdoc=master }
     - { rvm: 2.0.0, env: rdoc=master }
     - { rvm: 2.1.0, env: rdoc=master }

--- a/sdoc.gemspec
+++ b/sdoc.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.require_path = 'lib'
 
+  s.required_ruby_version = Gem::Requirement.new('>= 1.9.3')
   s.required_rubygems_version = Gem::Requirement.new(">= 1.3.6") if
     s.respond_to? :required_rubygems_version=
 
@@ -22,7 +23,6 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md"]
 
   s.add_runtime_dependency("rdoc", "~> 4.0")
-  s.add_runtime_dependency("json", "~> 1.7", ">= 1.7.7")
 
   s.files         = `git ls-files`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
it is same reason as https://github.com/rdoc/rdoc/pull/412

And also needs bump version rdoc 5.0, I think.