### PR TITLE
Depend on released version of RDoc 5

### DIFF
--- a/sdoc.gemspec
+++ b/sdoc.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = ["README.md"]
 
-  s.add_runtime_dependency("rdoc", "5.0.0.beta2")
+  s.add_runtime_dependency("rdoc", "5.0.0")
 
   s.files         = `git ls-files`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
I don't want to install rdoc 5 beta2 to my newly installed ruby 2.4.