### PR TITLE
Remove some useless requires

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
 matrix:
   allow_failures:
     - env: rdoc=master
+    - rvm: jruby-head
   include:
     - { rvm: 1.9.3, env: rdoc=master }
     - { rvm: 2.0.0, env: rdoc=master }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,5 @@
-require 'rubygems'
 require 'bundler/setup'
 
 require 'sdoc'
-
-require 'rdoc/test_case'
 
 require 'minitest/autorun'


### PR DESCRIPTION
Hi,

That's just a tiny pull request that removes some useless requires ; one for 1.8.7 compatibility which is no longer necessary as of https://github.com/zzak/sdoc/commit/c28efc8d4ebe0a50ed1072f3e4041657b149b634. Also, requiring `rdoc/test_case` seems useless since all tests pass.

Have a nice day !