### PR TITLE
Use HTML 5 for templates

### DIFF
--- a/lib/rdoc/generator/template/merge/index.rhtml
+++ b/lib/rdoc/generator/template/merge/index.rhtml
@@ -1,9 +1,7 @@
-<!DOCTYPE html
-     PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN"
-     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+  <meta charset="utf-8">
 
   <title><%= @title %></title>
 </head>

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <title><%= h klass.full_name %></title>
-    <meta http-equiv="Content-Type" content="text/html; charset=<%= @options.charset %>" />
+    <meta charset="<%= @options.charset %>" />
     <%= include_template '_head.rhtml', {:rel_prefix => rel_prefix} %>
 </head>
 

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <title><%= h file.name %></title>
-    <meta http-equiv="Content-Type" content="text/html; charset=<%= @options.charset %>" />
+    <meta charset="<%= @options.charset %>" />
     <%= include_template '_head.rhtml', {:rel_prefix => rel_prefix} %>
 </head>
 

--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -1,9 +1,7 @@
-<!DOCTYPE html
-     PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN"
-     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=<%= @options.charset %>" />
+    <meta charset="<%= @options.charset %>">
     <title><%= @options.title %></title>
 </head>
 <frameset cols="300,*" frameborder="1" border="1" bordercolor="#999999" framespacing="1">

--- a/lib/rdoc/generator/template/rails/resources/panel/index.html
+++ b/lib/rdoc/generator/template/rails/resources/panel/index.html
@@ -1,9 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
-    "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
-
+<!DOCTYPE html>
+<html lang="en">
 <head>
   <title>search index</title>
   <link rel="stylesheet" href="../css/reset.css" type="text/css" media="screen" charset="utf-8" />

--- a/lib/rdoc/generator/template/sdoc/resources/panel/index.html
+++ b/lib/rdoc/generator/template/sdoc/resources/panel/index.html
@@ -1,9 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
-    "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
-
+<!DOCTYPE html>
+<html lang="en">
 <head>
   <title>search index</title>
   <link rel="stylesheet" href="../css/reset.css" type="text/css" media="screen" charset="utf-8" />


### PR DESCRIPTION
Hi,

That's just a tiny pull request that uses HTML 5 inside the templates. The main audience of an API site is developers so we can safely assume that the users will have a recent browser.

Fixes #100.

Have a nice day !