### PR TITLE
Strip out HTML tags from search results description

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
+++ b/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
@@ -244,10 +244,10 @@ Searchdoc.Panel.prototype = $.extend({}, Searchdoc.Navigation, new function() {
         html += '</h1>';
         html += '<p>';
         if (typeof badge != 'undefined') {
-            html += '<span class="badge badge_' + (badge % 6 + 1) + '">' + escapeHTML(this.data.badges[badge] || 'unknown') + '</span>';
+            html += '<span class="badge badge_' + (badge % 6 + 1) + '">' + stripHTML(this.data.badges[badge] || 'unknown') + '</span>';
         }
         html += hlt(result.namespace) + '</p>';
-        if (result.snippet) html += '<p class="snippet">' + escapeHTML(result.snippet) + '</p>';
+        if (result.snippet) html += '<p class="snippet">' + stripHTML(result.snippet) + '</p>';
         li.innerHTML = html;
         jQuery.data(li, 'path', result.path);
         return li;
@@ -261,6 +261,25 @@ Searchdoc.Panel.prototype = $.extend({}, Searchdoc.Navigation, new function() {
         return html.replace(/[&<>]/g, function(c) {
             return '&#' + c.charCodeAt(0) + ';';
         });
+    }
+
+    function stripHTML(html) {
+        var in_tag = false;
+        var output = "";
+
+        for (var i = 0; i < html.length; i++) {
+            if (html[i] == '<'){
+                in_tag = true;
+            } else if (html[i] == '>') {
+                in_tag = false;
+                i++;
+            }
+
+            if (!in_tag && i < html.length)
+                output += html[i];
+        }
+
+        return output;
     }
 
 });

--- a/lib/rdoc/generator/template/sdoc/resources/js/searchdoc.js
+++ b/lib/rdoc/generator/template/sdoc/resources/js/searchdoc.js
@@ -245,10 +245,10 @@ Searchdoc.Panel.prototype = $.extend({}, Searchdoc.Navigation, new function() {
         html += '</a>';
         html += '<p>';
         if (typeof badge != 'undefined') {
-            html += '<span class="badge badge_' + (badge % 6 + 1) + '">' + escapeHTML(this.data.badges[badge] || 'unknown') + '</span>';
+            html += '<span class="badge badge_' + (badge % 6 + 1) + '">' + stripHTML(this.data.badges[badge] || 'unknown') + '</span>';
         }
         html += hlt(result.namespace) + '</p>';
-        if (result.snippet) html += '<p class="snippet">' + escapeHTML(result.snippet.replace(/^<p>/, '')) + '</p>';
+        if (result.snippet) html += '<p class="snippet">' + stripHTML(result.snippet.replace(/^<p>/, '')) + '</p>';
         li.innerHTML = html;
         jQuery.data(li, 'path', result.path);
         return li;
@@ -262,6 +262,25 @@ Searchdoc.Panel.prototype = $.extend({}, Searchdoc.Navigation, new function() {
         return html.replace(/[&<>]/g, function(c) {
             return '&#' + c.charCodeAt(0) + ';';
         });
+    }
+
+    function stripHTML(html) {
+        var in_tag = false;
+        var output = "";
+
+        for (var i = 0; i < html.length; i++) {
+            if (html[i] == '<'){
+                in_tag = true;
+            } else if (html[i] == '>') {
+                in_tag = false;
+                i++;
+            }
+
+            if (!in_tag && i < html.length)
+                output += html[i];
+        }
+
+        return output;
     }
 
 });


### PR DESCRIPTION
Hello,

This pull request strips out HTML tags from search results description. This will display search results without any HTML code since, at the moment, all results start with an escaped `<p>` tag.

This is how it looks at the moment on the Rails API:

<img width="300" alt="capture d ecran 2017-07-21 a 20 01 27" src="https://user-images.githubusercontent.com/354185/28476600-de3dbc5c-6e50-11e7-9e8b-fcf6f2f127eb.png">

And how it looks with this patch:

<img width="298" alt="capture d ecran 2017-07-21 a 20 08 51" src="https://user-images.githubusercontent.com/354185/28476614-e8cbde4c-6e50-11e7-9863-e1c1d670c18b.png">

Also, here's [a tiny benchmark](https://gist.github.com/robin850/140ddf33cb55fccf5871500299cad301) showing that `stripHTML` is faster than `escapeHTML` by the way.

Have a nice day !