### PR TITLE
Fix helper method `strip_tags`

### DIFF
--- a/lib/sdoc/helpers.rb
+++ b/lib/sdoc/helpers.rb
@@ -21,7 +21,7 @@ module SDoc::Helpers
   #
   #   strip_tags("<strong>Hello world</strong>") => "Hello world"
   def strip_tags(text)
-    text.gsub(/\<\/?[a-zA-Z\s"\.\/\=]+\>/, "")
+    text.gsub(%r{</?[^>]+?>}, "")
   end
 
   # Truncates a given string. It tries to take whole sentences to have

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -10,10 +10,12 @@ describe SDoc::Helpers do
   describe "#strip_tags" do
     it "should strip out HTML tags from the given string" do
       strings = [
-        [ %(<strong>Hello world</strong>),                 "Hello world"       ],
-        [ %(<a href="Streams.html">Streams</a> are great), "Streams are great" ],
-        [ %(<a href="../Base.html">Base</a>),              "Base"              ],
-        [ %(Some<br>\ntext),                               "Some\ntext"        ]
+        [ %(<strong>Hello world</strong>),                                      "Hello world"          ],
+        [ %(<a href="Streams.html">Streams</a> are great),                      "Streams are great"    ],
+        [ %(<a href="https://github.com?x=1&y=2#123">zzak/sdoc</a> Standalone), "zzak/sdoc Standalone" ],
+        [ %(<h1 id="module-AR::Cb-label-Foo+Bar">AR Cb</h1>),                   "AR Cb"                ],
+        [ %(<a href="../Base.html">Base</a>),                                   "Base"                 ],
+        [ %(Some<br>\ntext),                                                    "Some\ntext"           ]
       ]
 
       strings.each do |(html, stripped)|


### PR DESCRIPTION
### Summary

- I've found a bug on RoR [apidoc](http://edgeapi.rubyonrails.org/classes/ActiveSupport/Cache/MemCacheStore.html) which is generated by sdoc.
- It seems that current regex in strip_tags method is not enough to strip html tags.

### Before

```html
<meta name="description" content="A cache store implementation which stores data in Memcached: <a href="https://memcached.org">memcached.org  This is currently the most popular cache store for production websites.">
<meta property="og:description" content="A cache store implementation which stores data in Memcached: <a href="https://memcached.org">memcached.org  This is currently the most popular cache store for production websites.">
```

### After

```html
<meta name="description" content="A cache store implementation which stores data in Memcached: memcached.org  This is currently the most popular cache store for production websites.  Special features:  Clustering and load balancing.">
<meta property="og:description" content="A cache store implementation which stores data in Memcached: memcached.org  This is currently the most popular cache store for production websites.  Special features:  Clustering and load balancing.">
```