### PR TITLE
Remove problematic line comments in ERB templates

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -209,8 +209,8 @@
             </div>
             <% end %>
           </div>
-        <% end #methods.each %>
-      <% end #visibilities.each %>
-    <% end #context.methods_by_type %>
-  <% end #context.each_section %>
+        <% end %><%# methods.each %>
+      <% end %><%# visibilities.each %>
+    <% end %><%# context.methods_by_type %>
+  <% end %><%# context.each_section %>
 </div>

--- a/lib/rdoc/generator/template/sdoc/_context.rhtml
+++ b/lib/rdoc/generator/template/sdoc/_context.rhtml
@@ -209,8 +209,8 @@
             </div>
             <% end %>
           </div>
-        <% end #methods.each %>
-      <% end #visibilities.each %>
-    <% end #context.methods_by_type %>
-  <% end #context.each_section %>
+        <% end %><%# methods.each %>
+      <% end %><%# visibilities.each %>
+    <% end %><%# context.methods_by_type %>
+  <% end %><%# context.each_section %>
 </div>


### PR DESCRIPTION
We can't put line comments before the closing ERB tag. For example, an
ERB input:

	Before
	  <% if true %>
	  <% end # Comment %>
	After

will be compiled into:

	#coding:UTF-8
	_erbout = String.new; _erbout.concat "Before\n"
	; _erbout.concat "  ";  if true ; _erbout.concat "\n"
	; _erbout.concat "  ";  end # Comment ; _erbout.concat "\n"
	; _erbout.concat "After\n"
	; _erbout.force_encoding(__ENCODING__)

This happens to be syntactically valid as Ruby, but a newline character
after the end keyword is eaten unexpectedly.