### PR TITLE
Unused variables

### DIFF
--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -125,7 +125,6 @@ class RDoc::Generator::SDoc
     @classes.each do |klass|
       debug_msg "  working on %s (%s)" % [ klass.full_name, klass.path ]
       outfile     = @outputdir + klass.path
-      rel_prefix  = @outputdir.relative_path_from( outfile.dirname )
 
       debug_msg "  rendering #{outfile}"
       self.render_template( templatefile, binding(), outfile ) unless @options.dry_run
@@ -140,7 +139,6 @@ class RDoc::Generator::SDoc
     @files.each do |file|
       outfile     = @outputdir + file.path
       debug_msg "  working on %s (%s)" % [ file.full_name, outfile ]
-      rel_prefix  = @outputdir.relative_path_from( outfile.dirname )
 
       debug_msg "  rendering #{outfile}"
       self.render_template( templatefile, binding(), outfile ) unless @options.dry_run


### PR DESCRIPTION
From running rails's tests with `env RUBYOPT="-W2" bundle exec rake`:

```ruby
/Users/d/.rvm/gems/ruby-2.4.1/bundler/gems/sdoc-0e340352f3ab/lib/sdoc/generator.rb:199: warning: assigned but unused variable - rel_prefix
/Users/d/.rvm/gems/ruby-2.4.1/bundler/gems/sdoc-0e340352f3ab/lib/sdoc/generator.rb:214: warning: assigned but unused variable - rel_prefix
```