### PR TITLE
Deprecate safe_level of ERB.new in Ruby 2.6

### DIFF
--- a/lib/sdoc/templatable.rb
+++ b/lib/sdoc/templatable.rb
@@ -6,7 +6,11 @@ module SDoc::Templatable
   ### Both +templatefile+ and +outfile+ should be Pathname-like objects.
   def eval_template(templatefile, context)
     template_src = templatefile.read
-    template = ERB.new( template_src, nil, '<>' )
+    template = if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+      ERB.new( template_src, trim_mode: '<>' )
+    else
+      ERB.new( template_src, nil, '<>' )
+    end
     template.filename = templatefile.to_s
 
     begin


### PR DESCRIPTION
This PR suppresses the following warnings when using Ruby 2.6.0-dev.

```console
% ruby -v
ruby 2.6.0dev (2018-05-08 trunk 63359) [x86_64-darwin17]
% RUBYOPT='-w' sdoc
(snip)

Generating SDoc format into /Users/koic/src/github.com/zzak/sdoc/doc...
/Users/koic/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/sdoc-1.0.0/lib/sdoc/templatable.rb:9:
warning: Passing safe_level with the 2nd argument of ERB.new is
deprecated. Do not use it, and specify other arguments as keyword arguments.
/Users/koic/.rbenv/versions/2.6.0-dev/lib/ruby/gems/2.6.0/gems/sdoc-1.0.0/lib/sdoc/templatable.rb:9:
warning: Passing trim_mode with the 3rd argument of ERB.new is
deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```

The interface of `ERB.new` will change from Ruby 2.6.

> Add :trim_mode and :eoutvar keyword arguments to ERB.new.
> Now non-keyword arguments other than first one are softly deprecated
> and will be removed when Ruby 2.5 becomes EOL. [Feature #14256]

https://github.com/ruby/ruby/blob/2311087/NEWS#stdlib-updates-outstanding-ones-only

This PR uses `ERB.instance_method(:initialize).parameters.assoc(:key)` to switch `ERB.new` interface. Because SDoc supports multiple Ruby versions, it need to use the appropriate interface. This approach is built into Ruby.
https://github.com/ruby/ruby/commit/3406c5d