### PR TITLE
Fix panel header overflow issue in Chrome

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -29,6 +29,7 @@
             position: absolute;
             left: 0; top: 0;
             z-index: 300;
+            overflow: hidden;
         }
 
         .panel .header input


### PR DESCRIPTION
This should fix an issue with the panel header under Chrome (at least on macOS).

<img width="767" alt="Screen Shot 2020-02-13 at 3 35 12 PM" src="https://user-images.githubusercontent.com/131752/76654120-8522c600-6527-11ea-8ee9-fdc49dfd0068.png">

I've tested this change in the inspector, but not "for reals", but I'm pretty sure it will work 🤞.

The need for this fix would probably be obsoleted by #137, but this is a much smaller change

cc @eileencodes @smashwilson who both spotted the issue