### PR TITLE
Use h2 instead of h1 for banner header

### DIFF
--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -27,7 +27,7 @@
         <% if ENV['HORO_PROJECT_NAME'] %>
             <span><%= ERB::Util.html_escape(ENV['HORO_PROJECT_NAME']) %> <%= ERB::Util.html_escape(ENV['HORO_PROJECT_VERSION']) %></span><br />
         <% end %>
-        <h1>
+        <h2>
             <span class="type"><%= klass.module? ? 'Module' : 'Class' %></span>
             <%= h klass.full_name %>
             <% if klass.type == 'class' %>
@@ -39,7 +39,7 @@
                     <% end %>
                 </span>
             <% end %>
-        </h1>
+        </h2>
         <ul class="files">
             <% klass.in_files.each do |file| %>
             <li><a href="<%= "#{rel_prefix}/#{h file.path}" %>"><%= h file.absolute_name %></a></li>

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -14,9 +14,9 @@
         <% if ENV['HORO_PROJECT_NAME'] %>
             <span><%= ERB::Util.html_escape(ENV['HORO_PROJECT_NAME']) %> <%= ERB::Util.html_escape(ENV['HORO_PROJECT_VERSION']) %></span><br />
         <% end %>
-        <h1>
+        <h2>
             <%= h file.name %>
-        </h1>
+        </h2>
         <ul class="files">
             <%
                 github = github_url(file.relative_name) if options.github

--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -16,9 +16,9 @@
         <% if ENV['HORO_PROJECT_NAME'] %>
             <span><%= ERB::Util.html_escape(ENV['HORO_PROJECT_NAME']) %> <%= ERB::Util.html_escape(ENV['HORO_PROJECT_VERSION']) %></span><br />
         <% end %>
-        <h1>
+        <h2>
             <%= h index.name %>
-        </h1>
+        </h2>
         <ul class="files">
             <li><%= h index.relative_name %></li>
             <li>Last modified: <%= index.last_modified %></li>

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -125,20 +125,20 @@ ol li
     padding: 1em;
     box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.2);
 }
-.banner h1
+.banner h2
 {
     font-size: 1.2em;
     margin: 0;
 }
 
-.banner h1 .type
+.banner h2 .type
 {
     font-size: 0.833em;
     display:block;
 }
 
-.banner h1 .type,
-.banner h1 .parent
+.banner h2 .type,
+.banner h2 .parent
 {
     color: #CCC;
 }


### PR DESCRIPTION
For SEO purposes a page should only have 1 h1 header.
In the banner we can use h2 instead.