### PR TITLE
Use 1 metatag for keywords

### DIFF
--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -13,10 +13,7 @@
     <meta property="og:description" content="<%= human_desc %>">
   <% end %>
 
-    <meta name="keywords" content="<%= klass.full_name %> class">
-  <% unless klass.method_list.empty? %>
-    <meta name="keywords" content="<%= klass.method_list.map(&:name).join(", ") %>">
-  <% end %>
+    <meta name="keywords" content="<%= klass.full_name %> class, <%= klass.method_list.map(&:name).join(", ") %>">
 </head>
 
 <body>


### PR DESCRIPTION
If a class has a method_list, add these to the existing keywords metatag instead of creating a new metatag.