### PR TITLE
Fix arrow icons for selected panel items

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -320,13 +320,13 @@
 
         .panel .tree ul li.current .icon
         {
-            background: url(../i/arrow-right.svg);
+            background: url(../i/arrow-down-current.svg);
             background-size: 10px;
         }
 
         .panel .tree ul li.current.closed .icon
         {
-            background: url(../i/arrow-down.svg);
+            background: url(../i/arrow-right-current.svg);
             background-size: 10px;
         }
 

--- a/lib/rdoc/generator/template/rails/resources/i/arrow-down-current.svg
+++ b/lib/rdoc/generator/template/rails/resources/i/arrow-down-current.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 30 30" style="enable-background:new 0 0 30 30;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<polygon class="st0" points="27.8,3.1 0.6,3.1 14.2,26.2 "/>
+</svg>

--- a/lib/rdoc/generator/template/rails/resources/i/arrow-right-current.svg
+++ b/lib/rdoc/generator/template/rails/resources/i/arrow-right-current.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 30 30" style="enable-background:new 0 0 30 30;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<polygon class="st0" points="2.6,1.1 2.6,28.2 25.8,14.6 "/>
+</svg>


### PR DESCRIPTION
If an item was selected in the panel, the arrow icon was pointing in the
wrong direction.

This uses the correct direction of the arrow.
We also add a new white icon for the selected item for improved
legibility.

## Before
<img width="301" alt="image" src="https://user-images.githubusercontent.com/28561/98483275-2113e700-2207-11eb-8375-efd7ca9c2525.png">

## After
<img width="301" alt="image" src="https://user-images.githubusercontent.com/28561/98483238-ed38c180-2206-11eb-81ed-f89c6d0b77b9.png">
