### PR TITLE
Add rack application config for testing locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ rake test:rails
 This task will generate documentation for the Rails master branch.
 Since the task doesn't do any file filtering it contains a lot of extra pages.
 
+To view the just generated documentation start up a rack application by running:
+
+```bash
+rackup config.ru
+```
+
+Then open http://localhost:9292 in the browser to view the documentation.
+
 ### Who?
 
 * Vladimir Kolesnikov ([voloko](https://github.com/voloko))

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,30 @@
+# Rack application for serving the documentation locally.
+# After generating the documentation run:
+#
+#   bundle exec rackup config.ru
+#
+require 'bundler/setup'
+
+root = "doc/rails"
+unless Dir.exists?(root)
+  puts <<~MESSAGE
+    Could not find any docs in #{root}.
+    Run the following command to generate sample documentation:
+      bundle exec rake test:rails
+  MESSAGE
+  exit
+end
+
+use Rack::Static,
+  :urls => ["/files", "/images", "/js", "/css", "/panel", "/i", "/classes"],
+  :root => root
+run lambda { |env|
+  [
+    200,
+    { 
+      'Content-Type'  => 'text/html',
+      'Cache-Control' => 'public, max-age=86400'
+    },
+    File.open("#{root}/index.html", File::RDONLY)
+  ]
+}

--- a/sdoc.gemspec
+++ b/sdoc.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("rdoc", ">= 5.0")
 
+  s.add_development_dependency("rack")
+
   s.files         = `git ls-files`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 end


### PR DESCRIPTION
After switching to Turbolinks all asset paths are absolute.
This breaks opening the files locally in the browser.
To help testing locally add a rack application to serve the
documentation locally.

This is somewhat similar to  #136 but uses Rack::Static instead
to avoid security issues mentioned.