### PR TITLE
Use @options title for the index

### DIFF
--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -3,7 +3,7 @@
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-    <title><%= h index.name %></title>
+    <title><%= @options.title %></title>
     <meta http-equiv="Content-Type" content="text/html; charset=<%= @options.charset %>" />
     <%= include_template '_head.rhtml', {:rel_prefix => rel_prefix, tree_keys: []} %>
 </head>


### PR DESCRIPTION
In the migration to a css based layout the title of the index page got
changed. This reverts the title change back to the @options.title.