### PR TITLE
Fix overflow CSS property of panel elements

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -57,7 +57,7 @@
             top: 40px;
             left: 0;
             width: 100%;
-            overflow-y: scroll;
+            overflow-y: auto;
             overflow-x: hidden;
             z-index: 2;
         }
@@ -224,7 +224,7 @@
             bottom: 0;
             left: 0;
             width: 100%;
-            overflow-y: scroll;
+            overflow-y: auto;
             overflow-x: hidden;
             z-index: 30;
         }


### PR DESCRIPTION
Use `overflow-y: auto` for both tree and result divs.
Using an `orverflow-y: scroll` results in some browsers always displaying the scroll area even when there's no need of a scroll.

Fixes issue #143 
