### PR TITLE
Using HTML5 doctype accross all HTML files

### DIFF
--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <title><%= @options.title %></title>
     <meta http-equiv="Content-Type" content="text/html; charset=<%= @options.charset %>" />

--- a/lib/rdoc/generator/template/rails/search_index.rhtml
+++ b/lib/rdoc/generator/template/rails/search_index.rhtml
@@ -1,5 +1,7 @@
-<html>
-    <head>File index</head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>File index</title>
     <body>
     <% @files.each do |file| %>
       <a href="../<%= file.path %>"><%= file.relative_name %></a>

--- a/lib/rdoc/generator/template/rails/search_index.rhtml
+++ b/lib/rdoc/generator/template/rails/search_index.rhtml
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>File index</title>
+</head>
     <body>
     <% @files.each do |file| %>
       <a href="../<%= file.path %>"><%= file.relative_name %></a>

--- a/lib/rdoc/generator/template/rails/search_index.rhtml
+++ b/lib/rdoc/generator/template/rails/search_index.rhtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>File index</title>
+    <title>File Index</title>
 </head>
     <body>
     <% @files.each do |file| %>

--- a/lib/rdoc/generator/template/sdoc/class.rhtml
+++ b/lib/rdoc/generator/template/sdoc/class.rhtml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <title><%= h klass.full_name %></title>
     <meta http-equiv="Content-Type" content="text/html; charset=<%= @options.charset %>" />

--- a/lib/rdoc/generator/template/sdoc/file.rhtml
+++ b/lib/rdoc/generator/template/sdoc/file.rhtml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <title><%= h file.name %></title>
     <meta http-equiv="Content-Type" content="text/html; charset=<%= @options.charset %>" />

--- a/lib/rdoc/generator/template/sdoc/index.rhtml
+++ b/lib/rdoc/generator/template/sdoc/index.rhtml
@@ -1,7 +1,5 @@
-<!DOCTYPE html
-     PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN"
-     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=<%= @options.charset %>" />
     <title><%= @options.title %></title>

--- a/lib/rdoc/generator/template/sdoc/resources/panel/index.html
+++ b/lib/rdoc/generator/template/sdoc/resources/panel/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>search index</title>
+  <title>Search Index</title>
   <link rel="stylesheet" href="../css/reset.css" type="text/css" media="screen" charset="utf-8" />
   <link rel="stylesheet" href="../css/panel.css" type="text/css" media="screen" charset="utf-8" />
   <script src="../js/search_index.js" type="text/javascript" charset="utf-8"></script>

--- a/lib/rdoc/generator/template/sdoc/search_index.rhtml
+++ b/lib/rdoc/generator/template/sdoc/search_index.rhtml
@@ -1,5 +1,7 @@
-<html>
-    <head>File index</head>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>File index</title>
     <body>
     <% @files.each do |file| %>
       <a href="../<%= file.path %>"><%= file.relative_name %></a>

--- a/lib/rdoc/generator/template/sdoc/search_index.rhtml
+++ b/lib/rdoc/generator/template/sdoc/search_index.rhtml
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>File index</title>
+</head>
     <body>
     <% @files.each do |file| %>
       <a href="../<%= file.path %>"><%= file.relative_name %></a>

--- a/lib/rdoc/generator/template/sdoc/search_index.rhtml
+++ b/lib/rdoc/generator/template/sdoc/search_index.rhtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>File index</title>
+    <title>File Index</title>
 </head>
     <body>
     <% @files.each do |file| %>


### PR DESCRIPTION
I ran [Lighthouse](https://web.dev/measure/) over https://api.rubyonrails.org/ & one of the things it warned about was:

> Page lacks the HTML doctype, thus triggering quirks-mode

![image](https://user-images.githubusercontent.com/325384/109175644-e9ad5400-777d-11eb-8c41-a879ec8b7fc5.png)

So I went through & update all the instances of the old HTML doctype to be the same as the HTML5 one :)

# Other Information

I've also deployed the `rake test:rails` site to [Netlify](https://gifted-shirley-590be0.netlify.app/) if you'd like to see the results in action.
