### PR TITLE
Adding viewport to views

### DIFF
--- a/lib/rdoc/generator/template/merge/index.rhtml
+++ b/lib/rdoc/generator/template/merge/index.rhtml
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-
   <title><%= @title %></title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
 </head>
 <frameset cols="300,*" frameborder="1" border="1" bordercolor="#999999" framespacing="1">
     <frame src="panel/index.html" title="Search" name="panel" />

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -3,6 +3,7 @@
 <head>
     <title><%= h klass.full_name %></title>
     <meta charset="<%= @options.charset %>" />
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= include_template '_head.rhtml', {:rel_prefix => rel_prefix, :tree_keys => klass.full_name.split('::') } %>
 
     <meta property="og:title" value="<%= klass.full_name %>">

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -3,6 +3,7 @@
 <head>
     <title><%= h file.name %></title>
     <meta charset="<%= @options.charset %>" />
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= include_template '_head.rhtml', {:rel_prefix => rel_prefix, :tree_keys => [] } %>
 </head>
 

--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -3,6 +3,7 @@
 <head>
     <title><%= @options.title %></title>
     <meta http-equiv="Content-Type" content="text/html; charset=<%= @options.charset %>" />
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= include_template '_head.rhtml', {:rel_prefix => rel_prefix, tree_keys: []} %>
 </head>
 

--- a/lib/rdoc/generator/template/rails/search_index.rhtml
+++ b/lib/rdoc/generator/template/rails/search_index.rhtml
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>File Index</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
 </head>
     <body>
     <% @files.each do |file| %>

--- a/lib/rdoc/generator/template/sdoc/class.rhtml
+++ b/lib/rdoc/generator/template/sdoc/class.rhtml
@@ -3,6 +3,7 @@
 <head>
     <title><%= h klass.full_name %></title>
     <meta http-equiv="Content-Type" content="text/html; charset=<%= @options.charset %>" />
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= include_template '_head.rhtml', {:rel_prefix => rel_prefix} %>
 
     <meta property="og:title" value="<%= klass.full_name %>">

--- a/lib/rdoc/generator/template/sdoc/file.rhtml
+++ b/lib/rdoc/generator/template/sdoc/file.rhtml
@@ -3,6 +3,7 @@
 <head>
     <title><%= h file.name %></title>
     <meta http-equiv="Content-Type" content="text/html; charset=<%= @options.charset %>" />
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= include_template '_head.rhtml', {:rel_prefix => rel_prefix} %>
 </head>
 

--- a/lib/rdoc/generator/template/sdoc/index.rhtml
+++ b/lib/rdoc/generator/template/sdoc/index.rhtml
@@ -3,6 +3,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=<%= @options.charset %>" />
     <title><%= @options.title %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
 </head>
 <frameset cols="300,*" frameborder="1" border="1" bordercolor="#999999" framespacing="1">
     <frame src="panel/index.html" title="Search" name="panel" />

--- a/lib/rdoc/generator/template/sdoc/resources/panel/index.html
+++ b/lib/rdoc/generator/template/sdoc/resources/panel/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <title>Search Index</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="../css/reset.css" type="text/css" media="screen" charset="utf-8" />
   <link rel="stylesheet" href="../css/panel.css" type="text/css" media="screen" charset="utf-8" />
   <script src="../js/search_index.js" type="text/javascript" charset="utf-8"></script>

--- a/lib/rdoc/generator/template/sdoc/search_index.rhtml
+++ b/lib/rdoc/generator/template/sdoc/search_index.rhtml
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <title>File Index</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
 </head>
     <body>
     <% @files.each do |file| %>


### PR DESCRIPTION
As part of: https://github.com/zzak/sdoc/issues/151

![image](https://user-images.githubusercontent.com/325384/110215663-e19e9400-7ea2-11eb-9a42-f41a8b99895a.png)

One of the lighthouse recommendation is:

>  Does not have a `<meta name="viewport">` tag with `width` or `initial-scale`

So I added one to all the views :) I used the one which ships with the current `rails new`.