### PR TITLE
Make panel responsive for mobile

### DIFF
--- a/lib/rdoc/generator/template/rails/_panel.rhtml
+++ b/lib/rdoc/generator/template/rails/_panel.rhtml
@@ -1,6 +1,9 @@
+<input type="checkbox" id="hamburger" class="panel_checkbox">
+<label class="panel_mobile_button" for="hamburger"><span></span> Menu</label>
 <div class="panel panel_tree" id="panel" data-turbolinks-permanent>
   <div class="header">
     <input type="text" placeholder="Search for a class, method, ..." autosave="searchdoc" results="10" id="search" autocomplete="off" />
+    <label class="panel_mobile_button_close" for="hamburger"><span></span> Close</label>
   </div>
   <div class="tree">
     <ul>

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -7,8 +7,10 @@ body {
   line-height: 1.25em;
 }
 
-.banner, #bodyContent {
-  margin-left: 300px;
+@media (min-width: 40em) {
+  .banner, #bodyContent {
+    margin-left: 300px;
+  }
 }
 
 a:link, a:active, a:visited, a:hover {

--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -1,7 +1,91 @@
 /* Panel (begin) */
+    .panel_checkbox, .panel_mobile_button, .panel_mobile_button_close
+    {
+        display: none;
+    }
+
+    @media (max-width: 39.99em) {
+        .panel_mobile_button {
+            display: block;
+            height: 40px;
+            position: sticky;
+            top: 0;
+            background: #000;
+            color: #fff;
+            padding-right: 10px;
+            text-align: right;
+            line-height: 40px;
+            cursor: pointer;
+        }
+        .panel_checkbox:checked ~ .panel_mobile_button {
+        }
+
+        .panel_checkbox:checked ~ .panel .panel_mobile_button_close {
+            display: block;
+            height: 40px;
+            position: absolute;
+            top: 0;
+            right: 10px;
+            z-index: 3000;
+            text-align: right;
+            line-height: 40px;
+            cursor: pointer;
+        }
+    }
+
+    .panel_mobile_button span {
+         position: relative;
+         display: inline-block;
+         width: 1em;
+         height: 0.55em;
+         margin-right: 0.3em;
+         border-top: 0.1em solid #fff;
+         border-bottom: 0.1em solid #fff;
+    }
+
+    .panel_mobile_button span:before {
+         content: "";
+         position: absolute;
+         top: 0.25em;
+         left: 0px;
+         width: 100%;
+         border-top: 0.1em solid #fff;
+    }
+
+    .panel_mobile_button_close span {
+         position: relative;
+         display: inline-block;
+         width: 1em;
+         height: 0.625em;
+    }
+
+    .panel_mobile_button_close span:before, .panel_mobile_button_close span:after {
+         content: "";
+         position: absolute;
+         top: 0.2em;
+         left: 0px;
+         width: 100%;
+         border-top: 0.1em solid #000;
+    }
+
+    .panel_mobile_button_close span:before {
+        -webkit-transform: rotate(45deg);
+        -moz-transform: rotate(45deg);
+        -ms-transform: rotate(45deg);
+        transform: rotate(45deg);
+    }
+
+    .panel_mobile_button_close span:after {
+        -webkit-transform: rotate(-45deg);
+        -moz-transform: rotate(-45deg);
+        -ms-transform: rotate(-45deg);
+        transform: rotate(-45deg);
+    }
+
     .panel
     {
         position: fixed;
+        top: 0;
         width: 300px;
         height: 100%;
         background: #FFF;
@@ -10,6 +94,34 @@
         overflow-x: hidden;
         border-right: 1px #ccc solid;
         line-height: 1;
+    }
+
+    @media (max-width: 39.99em) {
+        .panel
+        {
+            -webkit-transform:translate(-100%, 0);
+            -moz-transform:translate(-100%, 0);
+            -ms-transform:translate(-100%, 0);
+            transform:translate(-100%, 0);
+             -webkit-transition:transform 0s ease-in-out;
+            -moz-transition:transform 0s ease-in-out;
+            -ms-transition:transform 0s ease-in-out;
+            transition:transform 0s ease-in-out;
+            opacity: 0;
+            width: 100%
+        }
+
+        .panel_checkbox:checked ~ .panel {
+            -webkit-transform:translate(0, 0);
+            -moz-transform:translate(0, 0);
+            -ms-transform:translate(0, 0);
+            transform:translate(0, 0);
+            -webkit-transition:transform 0.3s ease-in-out;
+            -moz-transition:transform 0.3s ease-in-out;
+            -ms-transition:transform 0.3s ease-in-out;
+            transition:transform 0.3s ease-in-out;
+            opacity: 1;
+        }
     }
 
     .panel_tree .results,
@@ -27,9 +139,17 @@
             height: 40px;
             width: 300px;
             position: fixed;
+            position: sticky;
             left: 0; top: 0;
             z-index: 300;
             overflow-x: hidden;
+        }
+
+        @media (max-width: 39.99em) {
+            .panel .header
+            {
+                width: 100%;
+            }
         }
 
         .panel .header input
@@ -220,7 +340,6 @@
         {
             background: white;
             position: relative;
-            top: 40px;
             bottom: 0;
             left: 0;
             width: 100%;


### PR DESCRIPTION
On mobile we show the whole page including the search panel.
We can hide the panel and toggle it with css using a hidden checkbox.

This also changes the search input `position` from `fixed` to `sticky`.
This will make sure the search input and close button stick to the top.

<img width="612" alt="image" src="https://user-images.githubusercontent.com/28561/111218993-cab11d80-85d7-11eb-83fc-032cfe6ba95d.png">

Clicking on the "menu" in the top bar slides the panel into view:
<img width="609" alt="image" src="https://user-images.githubusercontent.com/28561/111218587-38a91500-85d7-11eb-8634-0cd7154abf55.png">

On mobile the menu bar sticks to the top:
<img width="608" alt="image" src="https://user-images.githubusercontent.com/28561/111218631-46f73100-85d7-11eb-8956-a4259dfa5bc9.png">
