### PR TITLE
Fix Ctrl+C copying

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
+++ b/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
@@ -32,10 +32,6 @@ Searchdoc.Navigation = new function() {
             case 74: // j
             case 75: // k
             case 76: // l
-            case 67: // c - dvorak
-            case 72: // h
-            case 84: // t
-            case 78: // n
                 this.clearMoveTimeout();
                 break;
         }
@@ -46,12 +42,10 @@ Searchdoc.Navigation = new function() {
         switch (e.keyCode) {
             case 37: //Event.KEY_LEFT:
             case 74: // j (qwerty)
-            case 72: // h (dvorak)
                 if (this.moveLeft()) e.preventDefault();
                 break;
             case 38: //Event.KEY_UP:
             case 73: // i (qwerty)
-            case 67: // c (dvorak)
                 if (e.keyCode == 38 || e.ctrlKey) {
                     if (this.moveUp()) e.preventDefault();
                     this.startMoveTimeout(false);
@@ -59,12 +53,10 @@ Searchdoc.Navigation = new function() {
                 break;
             case 39: //Event.KEY_RIGHT:
             case 76: // l (qwerty)
-            case 78: // n (dvorak)
                 if (this.moveRight()) e.preventDefault();
                 break;
             case 40: //Event.KEY_DOWN:
             case 75: // k (qwerty)
-            case 84: // t (dvorak)
                 if (e.keyCode == 40 || e.ctrlKey) {
                     if (this.moveDown()) e.preventDefault();
                     this.startMoveTimeout(true);
@@ -75,7 +67,6 @@ Searchdoc.Navigation = new function() {
                 if (this.$current) this.select(this.$current);
                 break;
             case 83: // s (qwerty)
-            case 79: // o (dvorak)
                 if (e.ctrlKey) {
                     $('#search').focus();
                     e.preventDefault();
@@ -481,4 +472,3 @@ Searchdoc.Tree.prototype = $.extend({}, Searchdoc.Navigation, new function() {
         return 5 + 18 * level + 'px';
     }
 });
-

--- a/lib/rdoc/generator/template/sdoc/resources/js/searchdoc.js
+++ b/lib/rdoc/generator/template/sdoc/resources/js/searchdoc.js
@@ -32,10 +32,6 @@ Searchdoc.Navigation = new function() {
             case 74: // j
             case 75: // k
             case 76: // l
-            case 67: // c - dvorak
-            case 72: // h
-            case 84: // t
-            case 78: // n
                 this.clearMoveTimeout();
                 break;
         }
@@ -46,12 +42,10 @@ Searchdoc.Navigation = new function() {
         switch (e.keyCode) {
             case 37: //Event.KEY_LEFT:
             case 74: // j (qwerty)
-            case 72: // h (dvorak)
                 if (this.moveLeft()) e.preventDefault();
                 break;
             case 38: //Event.KEY_UP:
             case 73: // i (qwerty)
-            case 67: // c (dvorak)
                 if (e.keyCode == 38 || e.ctrlKey) {
                     if (this.moveUp()) e.preventDefault();
                     this.startMoveTimeout(false);
@@ -59,12 +53,10 @@ Searchdoc.Navigation = new function() {
                 break;
             case 39: //Event.KEY_RIGHT:
             case 76: // l (qwerty)
-            case 78: // n (dvorak)
                 if (this.moveRight()) e.preventDefault();
                 break;
             case 40: //Event.KEY_DOWN:
             case 75: // k (qwerty)
-            case 84: // t (dvorak)
                 if (e.keyCode == 40 || e.ctrlKey) {
                     if (this.moveDown()) e.preventDefault();
                     this.startMoveTimeout(true);
@@ -75,7 +67,6 @@ Searchdoc.Navigation = new function() {
                 if (this.$current) this.select(this.$current);
                 break;
             case 83: // s (qwerty)
-            case 79: // o (dvorak)
                 if (e.ctrlKey) {
                     $('#search').focus();
                     e.preventDefault();


### PR DESCRIPTION
I noticed that it's not possible to copy stuff with Ctrl+C on https://api.rubyonrails.org.
I investigated why that is, and found that `searchdoc.js` overrides it as a navigation shortcut.
In my opinion, copying is more important, and there are two other shortcuts (arrow up and Ctrl+I) for navigating up, so this PR just disables the Ctrl+C navigation shortcut.