### PR TITLE
Remove TAB override in panel

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
+++ b/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
@@ -70,7 +70,6 @@ Searchdoc.Navigation = new function() {
                     this.startMoveTimeout(true);
                 }
                 break;
-            case 9: //Event.KEY_TAB:
             case 13: //Event.KEY_RETURN:
                 if (this.$current) this.select(this.$current);
                 break;

--- a/lib/rdoc/generator/template/sdoc/resources/js/searchdoc.js
+++ b/lib/rdoc/generator/template/sdoc/resources/js/searchdoc.js
@@ -70,7 +70,6 @@ Searchdoc.Navigation = new function() {
                     this.startMoveTimeout(true);
                 }
                 break;
-            case 9: //Event.KEY_TAB:
             case 13: //Event.KEY_RETURN:
                 if (this.$current) this.select(this.$current);
                 break;


### PR DESCRIPTION
TAB is overriden to load the highlighted item in the panel.
This is not recommended for those who rely on screen readers, keyboard
navigation, are visually impaired, or use other tools expecting (some
form) of WCAG compliance.

Partly fixes #158 