### PR TITLE
Remove outline from reset stylesheet

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/reset.css
+++ b/lib/rdoc/generator/template/rails/resources/css/reset.css
@@ -13,7 +13,6 @@ table, caption, tbody, tfoot, thead, tr, th, td {
 	margin: 0;
 	padding: 0;
 	border: 0;
-	outline: 0;
 	font-size: 100%;
 	vertical-align: baseline;
 	background: transparent;

--- a/lib/rdoc/generator/template/sdoc/resources/css/reset.css
+++ b/lib/rdoc/generator/template/sdoc/resources/css/reset.css
@@ -13,7 +13,6 @@ table, caption, tbody, tfoot, thead, tr, th, td {
 	margin: 0;
 	padding: 0;
 	border: 0;
-	outline: 0;
 	font-size: 100%;
 	vertical-align: baseline;
 	background: transparent;


### PR DESCRIPTION
Currently the outline of most elements is reset to 0.
This prevents those that use keyboard navigation to see which item is
currently selected with TAB.
Partly fixes #158 