### PR TITLE
Adding .sr-only 'skip to content' link

### DIFF
--- a/lib/rdoc/generator/template/rails/_head.rhtml
+++ b/lib/rdoc/generator/template/rails/_head.rhtml
@@ -17,23 +17,6 @@
 <script src="<%= rel_prefix %>/js/searcher.js" type="text/javascript" charset="utf-8" data-turbolinks-track="reload"></script>
 <script src="<%= rel_prefix %>/panel/tree.js" type="text/javascript" charset="utf-8" data-turbolinks-track="reload"></script>
 <script src="<%= rel_prefix %>/js/searchdoc.js" type="text/javascript" charset="utf-8" data-turbolinks-track="reload"></script>
-<script type="text/javascript" charset="utf-8">
-document.addEventListener("turbolinks:load", function() {
-  // Only initialize panel if not yet initialized
-  if(!$('#panel .tree ul li').length) {
-    $('#links').hide();
-    var panel = new Searchdoc.Panel($('#panel'), search_data, tree, '<%= rel_prefix %>/');
-    $('#search').focus();
-    var s = window.location.search.match(/\?q=([^&]+)/);
-    if (s) {
-      s = decodeURIComponent(s[1]).replace(/\+/g, ' ');
-      if (s.length > 0) {
-        $('#search').val(s);
-        panel.search(s, true);
-      }
-    }
-    panel.toggle(<%= tree_keys %>);
-  }
-})
-</script>
 
+<meta name="data-rel-prefix" content="<%= rel_prefix %>/">
+<meta name="data-tree-keys" content='<%= tree_keys %>'>

--- a/lib/rdoc/generator/template/rails/_panel.rhtml
+++ b/lib/rdoc/generator/template/rails/_panel.rhtml
@@ -1,8 +1,8 @@
 <input type="checkbox" id="hamburger" class="panel_checkbox">
 <label class="panel_mobile_button" for="hamburger"><span></span> Menu</label>
-<div class="panel panel_tree" id="panel" data-turbolinks-permanent>
+<nav class="panel panel_tree" id="panel" data-turbolinks-permanent>
   <div class="header">
-    <input type="text" placeholder="Search for a class, method, ..." autosave="searchdoc" results="10" id="search" autocomplete="off" tabindex="-1" />
+    <input type="text" placeholder="Search (/) for a class, method, ..." autosave="searchdoc" results="10" id="search" autocomplete="off" tabindex="-1" />
     <label class="panel_mobile_button_close" for="hamburger"><span></span> Close</label>
   </div>
   <div class="tree">
@@ -14,4 +14,4 @@
     </ul>
   </div>
   <a href="links.html" id="links">index</a>
-</div>
+</nav>

--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -18,6 +18,8 @@
 </head>
 
 <body>
+    <a class="sr-only sr-only-focusable" href="#content" data-turbolinks="false">Skip to Content</a>
+    <a class="sr-only sr-only-focusable" href="#search" data-turbolinks="false">Skip to Search</a>
 
     <%= include_template '_panel.rhtml' %>
 
@@ -45,8 +47,8 @@
         </ul>
     </div>
 
-    <div id="bodyContent">
+    <main id="bodyContent">
         <%= include_template '_context.rhtml', {:context => klass, :rel_prefix => rel_prefix} %>
-    </div>
+    </main>
   </body>
 </html>

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -8,6 +8,8 @@
 </head>
 
 <body>
+    <a class="sr-only sr-only-focusable" href="#content" data-turbolinks="false">Skip to Content</a>
+    <a class="sr-only sr-only-focusable" href="#search" data-turbolinks="false">Skip to Search</a>
 
     <%= include_template '_panel.rhtml' %>
 
@@ -32,8 +34,8 @@
         </ul>
     </div>
 
-    <div id="bodyContent">
+    <main id="bodyContent">
         <%= include_template '_context.rhtml', {:context => file, :rel_prefix => rel_prefix} %>
-    </div>
+    </main>
   </body>
 </html>

--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -8,6 +8,8 @@
 </head>
 
 <body>
+    <a class="sr-only sr-only-focusable" href="#content" data-turbolinks="false">Skip to Content</a>
+    <a class="sr-only sr-only-focusable" href="#search" data-turbolinks="false">Skip to Search</a>
 
     <%= include_template '_panel.rhtml' %>
 
@@ -24,9 +26,8 @@
         </ul>
     </div>
 
-    <div id="bodyContent">
+    <main id="bodyContent">
         <%= include_template '_context.rhtml', {:context => index } %>
-    </div>
+    </main>
   </body>
 </html>
-

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -374,3 +374,32 @@ p code {
   margin-bottom: 1px;
   padding: 0 5px;
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
+  position: fixed;
+  top: 10%;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+  padding: 2rem;
+  border: 4px solid #990000;
+  border-radius: 1rem;
+  box-shadow: 0 0.5rem 1rem rgb(0 0 0 / 15%) !important;
+  left: 40%;
+  z-index: 100;
+  background: #fff;
+  font-size: 2rem;
+}

--- a/lib/rdoc/generator/template/rails/resources/js/main.js
+++ b/lib/rdoc/generator/template/rails/resources/js/main.js
@@ -27,6 +27,23 @@ document.addEventListener("turbolinks:load", function() {
   });
 });
 
+document.addEventListener("turbolinks:load", function() {
+  // Only initialize panel if not yet initialized
+  if(!$('#panel .tree ul li').length) {
+    $('#links').hide();
+    var panel = new Searchdoc.Panel($('#panel'), search_data, tree, $('meta[name="data-rel-prefix"]').attr("content"));
+    var s = window.location.search.match(/\?q=([^&]+)/);
+    if (s) {
+      s = decodeURIComponent(s[1]).replace(/\+/g, ' ');
+      if (s.length > 0) {
+        $('#search').val(s);
+        panel.search(s, true);
+      }
+    }
+    panel.toggle(JSON.parse($('meta[name="data-tree-keys"]').attr("content")));
+  }
+});
+
 // Keep scroll position for panel
 (function() {
   var scrollTop = 0;

--- a/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
+++ b/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
@@ -39,6 +39,7 @@ Searchdoc.Navigation = new function() {
 
     this.onkeydown = function(e) {
         if (!this.navigationActive) return;
+
         switch (e.keyCode) {
             case 37: //Event.KEY_LEFT:
             case 74: // j (qwerty)
@@ -63,10 +64,17 @@ Searchdoc.Navigation = new function() {
                 }
                 break;
             case 13: //Event.KEY_RETURN:
+                if(e.target.dataset["turbolinks"]) { break; }
                 if (this.$current) this.select(this.$current);
                 break;
-            case 83: // s (qwerty)
+            case 83: // s (qwerty) - Focuses search
                 if (e.ctrlKey) {
+                    $('#search').focus();
+                    e.preventDefault();
+                }
+                break;
+            case 191: // / - Search by pressing "/"
+                if( !$('#search').is(":focus") ) {
                     $('#search').focus();
                     e.preventDefault();
                 }

--- a/lib/rdoc/generator/template/sdoc/class.rhtml
+++ b/lib/rdoc/generator/template/sdoc/class.rhtml
@@ -44,8 +44,8 @@
             <% end  %>
         </ul>
     </div>
-    <div id="bodyContent">
+    <main id="bodyContent">
         <%= include_template '_context.rhtml', {:context => klass, :rel_prefix => rel_prefix} %>
-    </div>
+    </main>
   </body>
 </html>

--- a/lib/rdoc/generator/template/sdoc/file.rhtml
+++ b/lib/rdoc/generator/template/sdoc/file.rhtml
@@ -21,8 +21,8 @@
         </ul>
     </div>
 
-    <div id="bodyContent">
+    <main id="bodyContent">
         <%= include_template '_context.rhtml', {:context => file, :rel_prefix => rel_prefix} %>
-    </div>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
Issue https://github.com/zzak/sdoc/issues/158

# Description

> Further wins: Add skip navigation link

This adds a link to the top of each of the pages with "Skip to content" as the text which is activated by tabbing through the site, when clicks it, it should take the user to the `#content` `<div>`. The CSS is taken from Bootstrap 4.

# Preview

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/325384/118855140-15cb0380-b89b-11eb-912e-06b7cd467dad.png">

[Also video on YouTube demoing this](https://youtu.be/RbXg8BLSDpY)

# Testing

## Skip to content

Chrome is the easiest to verify with, open the preview app & press "tab", a link saying "skip to content" . When you press "return" it should just the focus (and tab index) to the content.

## Search

Press `/` to quickly start searching, this is similar to before where we had `CTRL + S` but is more inline with other big sites approaches.