### PR TITLE
Adding netlify.toml - We can use it for PR previews

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,39 @@
+[build]
+  command = "rake install && sdoc -o doc/rails -T rails -f sdoc"
+  publish = "doc/rails"
+
+[build.processing]
+  skip_processing = false
+[build.processing.css]
+  bundle = true
+  minify = true
+[build.processing.js]
+  bundle = true
+  minify = true
+[build.processing.html]
+  pretty_urls = true
+[build.processing.images]
+  compress = true
+
+[[headers]]
+  for = "*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-XSS-Protection = "1; mode=block"
+    X-Content-Type-Options = "nosniff"
+    Content-Security-Policy = '''
+      object-src  'none';
+      worker-src  'none';
+      block-all-mixed-content;
+      upgrade-insecure-requests;'''
+    Strict-Transport-Security = "max-age=15552000; includeSubDomains"
+    Referrer-Policy = "no-referrer-when-downgrade"
+    Cache-Control = "public, max-age=604800, s-max-age=604800"
+
+[[headers]]
+  for = "/"
+
+[[headers]]
+  for = "/*.(png|jpg|js|css|svg|woff|ttf|eot|ico|woff2)"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, s-max-age=31536000"


### PR DESCRIPTION
Context https://github.com/zzak/sdoc/issues/162

We could totally use Netlify to preview changes we're making to the docs, this could make reviewing PRs way easier.

# What is this change?

This is the configuration file we use to tell Netlify how to build our preview, along with some sensible default headers.

# What is needed after this?

We'd need @zzak to connect this Repository to Netlify to enable auto building when a PR is made. We should be able to use the free tier for our needs also :D - I'm happy to jump on a Zoom call or something to help guide through this process.