### PR TITLE
Generate testing rails docs without test classes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,9 @@ namespace :test do
     rdoc.rdoc_dir = 'doc/rails'
     rdoc.generator = 'sdoc'
     rdoc.template = 'rails'
+    rdoc.title = 'Ruby on Rails'
+    rdoc.main = 'rails/README.md'
+    rdoc.options << '--exclude=test'
 
     rdoc.rdoc_files.include("rails/")
   end


### PR DESCRIPTION
Options updated for generated test rails documentation. With them, it's faster, and more looks like real life API.

### Before

```
  Files:       3438

  Classes:     4005 ( 3612 undocumented)
  Modules:      863 (  651 undocumented)
  Constants:    887 (  834 undocumented)
  Attributes:   891 (  836 undocumented)
  Methods:    23299 (20050 undocumented)

  Total:      29945 (25983 undocumented)
   13.23% documented

  Elapsed: 155.0s
```

<img width="1366" alt="Screenshot 2021-04-18 at 12 37 08" src="https://user-images.githubusercontent.com/426230/115141173-994ac800-a043-11eb-94e1-3760e9afe22e.png">


### After

```
  Files:      1527

  Classes:     570 ( 243 undocumented)
  Modules:     510 ( 327 undocumented)
  Constants:   407 ( 367 undocumented)
  Attributes:  455 ( 412 undocumented)
  Methods:    4713 (1883 undocumented)

  Total:      6655 (3232 undocumented)
   51.44% documented

  Elapsed: 42.6s
```

<img width="1395" alt="Screenshot 2021-04-18 at 12 41 08" src="https://user-images.githubusercontent.com/426230/115141232-cc8d5700-a043-11eb-8c81-968f35bd52ad.png">

 