### PR TITLE
Add test rake task to generate ruby documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 /.rake_tasks~
 /*.gem
 /rails/
+/ruby/

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ rake test:rails
 ```
 
 This task will generate documentation for the Rails main branch.
-Since the task doesn't do any file filtering it contains a lot of extra pages.
 
 To view the just generated documentation start up a rack application by running:
 

--- a/README.md
+++ b/README.md
@@ -92,14 +92,19 @@ As maintainer of both projects, I'll see if I can identify the root of the cause
 
 ## Contributing
 
-If you'd like to contribute you can generate the Rails documentation by running:
+If you'd like to contribute you can generate the Rails main branch documentation by running:
 
 ```bash
 rake test:rails
 ```
 
-This task will generate documentation for the Rails main branch.
+You can generate the Ruby default branch documentation by running:
 
+```bash
+rake test:ruby
+```
+
+The generated documentation will be put into `doc/public` directory.
 To view the just generated documentation start up a rack application by running:
 
 ```bash

--- a/Rakefile
+++ b/Rakefile
@@ -15,9 +15,14 @@ require 'sdoc'
 require 'rdoc/task'
 
 rails = File.expand_path "rails"
+ruby = File.expand_path "ruby"
 
 directory rails do
   sh "git clone --depth=1 https://github.com/rails/rails"
+end
+
+directory ruby do
+  sh "git clone --depth=1 https://github.com/ruby/ruby"
 end
 
 namespace :test do
@@ -43,5 +48,23 @@ namespace :test do
     rdoc.options << '--exclude=test'
 
     rdoc.rdoc_files.include("rails/")
+  end
+
+  desc 'Generates test ruby documentation'
+  task :ruby => [ruby, :generate_ruby] do
+    FileUtils.mv(
+      File.expand_path('doc/ruby'),
+      File.expand_path('doc/public')
+    )
+  end
+
+  RDoc::Task.new(:generate_ruby) do |rdoc|
+    rdoc.rdoc_dir = 'doc/ruby'
+    rdoc.generator = 'sdoc'
+    rdoc.template = 'rails'
+    rdoc.title = 'Ruby'
+    rdoc.main = 'ruby/README.md'
+
+    rdoc.rdoc_files.include("ruby/")
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -21,9 +21,20 @@ directory rails do
 end
 
 namespace :test do
-  task :rails => rails
+  desc 'Deletes all generated test documentation'
+  task :reset_docs do
+    FileUtils.remove_dir(File.expand_path('doc'), force: true)
+  end
 
-  RDoc::Task.new(:rails) do |rdoc|
+  desc 'Generates test rails documentation'
+  task :rails => [rails, :generate_rails] do
+    FileUtils.mv(
+      File.expand_path('doc/rails'),
+      File.expand_path('doc/public')
+    )
+  end
+
+  RDoc::Task.new(:generate_rails) do |rdoc|
     rdoc.rdoc_dir = 'doc/rails'
     rdoc.generator = 'sdoc'
     rdoc.template = 'rails'

--- a/config.ru
+++ b/config.ru
@@ -5,7 +5,7 @@
 #
 require 'bundler/setup'
 
-root = "doc/rails"
+root = "doc/public"
 unless Dir.exists?(root)
   puts <<~MESSAGE
     Could not find any docs in #{root}.
@@ -21,7 +21,7 @@ use Rack::Static,
 run lambda { |env|
   [
     200,
-    { 
+    {
       'Content-Type'  => 'text/html',
       'Cache-Control' => 'public, max-age=86400'
     },

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
-  command = "rake install && sdoc -o doc/rails -T rails -f sdoc"
-  publish = "doc/rails"
+  command = "rake install && sdoc -o doc/public -T rails -f sdoc"
+  publish = "doc/public"
 
 [build.processing]
   skip_processing = false


### PR DESCRIPTION
I'm trying to fix merge script (https://github.com/zzak/sdoc/issues/152). For that I decided to add script to generate ruby documentation.

To be able run both rails/ruby docs, I changed rack config a bit.

Generated ruby docs look like
<img width="1372" alt="Screenshot 2021-04-23 at 01 45 17" src="https://user-images.githubusercontent.com/426230/115794289-6ce1d380-a3d6-11eb-9ad2-86c3b2c6d8f9.png">

and some stats

```
  Files:        809

  Classes:      993 ( 285 undocumented)
  Modules:      195 (  47 undocumented)
  Constants:   1194 ( 464 undocumented)
  Attributes:   983 ( 244 undocumented)
  Methods:     8817 (1401 undocumented)

  Total:      12182 (2441 undocumented)
   79.96% documented

  Elapsed: 46.4s
```
