### PR TITLE
Fix panel.css

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -98,7 +98,7 @@
             left: -100%;
             width: 100%;
             bottom: 0;
-            visibility: hidden; 
+            visibility: hidden;
         }
 
         .panel_checkbox:checked ~ .panel {
@@ -113,7 +113,7 @@
         }
     }
 
-    .panel_tree .results,
+    .panel_tree .result,
     .panel_results .tree
     {
         display: none;


### PR DESCRIPTION
For search results wrong selector was used.
So when you delete search query, search results were not disappeared

Screenshot from https://api.rubyonrails.org

<img width="1436" alt="Screenshot 2021-05-09 at 03 27 27" src="https://user-images.githubusercontent.com/426230/117556914-90fc1080-b076-11eb-9841-1e26ecd9ef4b.png">
