### PR TITLE
Remove redundant CSS rule breaking link hover visuals in headings

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -31,10 +31,6 @@ h1 a, h2 a, .banner a {
   color: #fff;
 }
 
-h1 a:hover, h2 a:hover {
-  color: #fff;
-}
-
 p {
   margin-bottom: 1em;
   text-align: justify;


### PR DESCRIPTION
This commit fixes h1 and h2 headings which include links, in the Rails documentation.

These are some of the pages affected:

* https://edgeapi.rubyonrails.org/classes/ActiveSupport/StringInquirer.html
* https://edgeapi.rubyonrails.org/classes/ActionController/Base.html
* https://edgeapi.rubyonrails.org/classes/Rails/Railtie.html
