### PR TITLE
Suppress unused variable warnings

### DIFF
--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -118,7 +118,7 @@ class RDoc::Generator::SDoc
     debug_msg "Generating index file in #@outputdir"
     templatefile = @template_dir + 'index.rhtml'
     outfile      = @outputdir + 'index.html'
-    rel_prefix  = @outputdir.relative_path_from( outfile.dirname )
+    rel_prefix = rel_prefix  = @outputdir.relative_path_from( outfile.dirname )
 
     self.render_template( templatefile, binding(), outfile ) unless @options.dry_run
   end
@@ -131,7 +131,7 @@ class RDoc::Generator::SDoc
     @classes.each do |klass|
       debug_msg "  working on %s (%s)" % [ klass.full_name, klass.path ]
       outfile     = @outputdir + klass.path
-      rel_prefix  = @outputdir.relative_path_from( outfile.dirname )
+      rel_prefix = rel_prefix  = @outputdir.relative_path_from( outfile.dirname )
 
       debug_msg "  rendering #{outfile}"
       self.render_template( templatefile, binding(), outfile ) unless @options.dry_run
@@ -146,7 +146,7 @@ class RDoc::Generator::SDoc
     @files.each do |file|
       outfile     = @outputdir + file.path
       debug_msg "  working on %s (%s)" % [ file.full_name, outfile ]
-      rel_prefix  = @outputdir.relative_path_from( outfile.dirname )
+      rel_prefix = rel_prefix  = @outputdir.relative_path_from( outfile.dirname )
 
       debug_msg "  rendering #{outfile}"
       self.render_template( templatefile, binding(), outfile ) unless @options.dry_run

--- a/lib/sdoc/templatable.rb
+++ b/lib/sdoc/templatable.rb
@@ -28,7 +28,7 @@ module SDoc::Templatable
   ### current context. Adds all +local_assigns+ to context
   def include_template(template_name, local_assigns = {})
     source = local_assigns.keys.map { |key| "#{key} = local_assigns[:#{key}];" }.join
-    templatefile = @template_dir + template_name
+    templatefile = templatefile = @template_dir + template_name
     eval("#{source};eval_template(templatefile, binding)")
   end
 


### PR DESCRIPTION
This PR suppresses "unused variable" warnings.


Note that these variables are actually used by `eval` and `binding`, so this PR just suppresses the warnings but doesn't remove the assignments.


----



By the way, I've got these warnings with IRB. With `RUBYOPT=-w`, they break IRB's completion feature, which is introduced Ruby 3.1-dev. The problem will be fixed by this patch.


before



https://user-images.githubusercontent.com/4361134/132087288-f59cebe5-4e47-48c7-aedb-79ab415d4903.mp4






after

https://user-images.githubusercontent.com/4361134/132087291-5d7cf971-80b6-42ad-8a9d-4a7e7ab2481c.mp4