### PR TITLE
Avoid displaying source toggler for ghost methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Master
 ======
 
+* #175 Avoid displaying source toggler for ghost methods
+
 2.2.0
 =====
 

--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -195,12 +195,20 @@
                 else
                   false
                 end
+
+                ghost = method.instance_of?(RDoc::GhostMethod)
               %>
               <p class="source-link">
-                Source:
-                <a href="javascript:toggleSource('<%= method.aref %>_source')" id="l_<%= method.aref %>_source">show</a>
+                <% if !ghost || github %> Source: <% end %>
+
+                <% unless ghost %>
+                  <a href="javascript:toggleSource('<%= method.aref %>_source')" id="l_<%= method.aref %>_source">show</a>
+                <% end %>
+
+                <% if !ghost && github %> | <% end %>
+
                 <% if github %>
-                  | <a href="<%= "#{github}#L#{line}" %>" target="_blank" class="github_url">on GitHub</a>
+                  <a href="<%= "#{github}#L#{line}" %>" target="_blank" class="github_url">on GitHub</a>
                 <% end %>
               </p>
               <div id="<%= method.aref %>_source" class="dyn-source">

--- a/lib/rdoc/generator/template/sdoc/_context.rhtml
+++ b/lib/rdoc/generator/template/sdoc/_context.rhtml
@@ -195,12 +195,20 @@
                 else
                   false
                 end
+
+                ghost = method.instance_of?(RDoc::GhostMethod)
               %>
               <p class="source-link">
-                Source:
-                <a href="javascript:toggleSource('<%= method.aref %>_source')" id="l_<%= method.aref %>_source">show</a>
+                <% if !ghost || github %> Source: <% end %>
+
+                <% unless ghost %>
+                  <a href="javascript:toggleSource('<%= method.aref %>_source')" id="l_<%= method.aref %>_source">show</a>
+                <% end %>
+
+                <% if !ghost && github %> | <% end %>
+
                 <% if github %>
-                  | <a href="<%= "#{github}#L#{line}" %>" target="_blank" class="github_url">on GitHub</a>
+                  <a href="<%= "#{github}#L#{line}" %>" target="_blank" class="github_url">on GitHub</a>
                 <% end %>
               </p>
               <div id="<%= method.aref %>_source" class="dyn-source">


### PR DESCRIPTION
Hello,

This pull request simply try to improve the source toggler for ghost methods.

Ghost methods don't have any source associated to their definition so let's avoid displaying a link to show an empty source for them.

We can still point to the definition on GitHub to ease finding the meta-programmed definition as it is most-likely in the same file.

Here's [an example](https://api.rubyonrails.org/v6.1.4/classes/AbstractController/Callbacks/ClassMethods.html#method-i-before_action) of the current behavior with ghost methods.

Have a nice day.