### PR TITLE
Make sidepanel work with relative paths/URLs

### DIFF
--- a/lib/rdoc/generator/template/rails/_head.rhtml
+++ b/lib/rdoc/generator/template/rails/_head.rhtml
@@ -1,22 +1,14 @@
-<%
-  # Turbolinks does not consider relative urls similar, resulting in page
-  # reloads and losing the context of the panel. Emptying the rel_prefix makes
-  # asset paths absolute. This breaks opening the docs locally. Maybe all
-  # generated docs should be in the same folder?
-  rel_prefix = ''
-%>
-<link rel="stylesheet" href="<%= "#{rel_prefix}/css/reset.css" %>" type="text/css" media="screen" data-turbolinks-track="reload" />
-<link rel="stylesheet" href="<%= "#{rel_prefix}/css/panel.css" %>" type="text/css" media="screen" data-turbolinks-track="reload" />
-<link rel="stylesheet" href="<%= "#{rel_prefix}/css/main.css" %>" type="text/css" media="screen" data-turbolinks-track="reload" />
-<link rel="stylesheet" href="<%= "#{rel_prefix}/css/github.css" %>" type="text/css" media="screen" data-turbolinks-track="reload" />
-<script src="<%= "#{rel_prefix}/js/jquery-3.5.1.min.js" %>" type="text/javascript" charset="utf-8" data-turbolinks-track="reload"></script>
-<script src="<%= "#{rel_prefix}/js/main.js" %>" type="text/javascript" charset="utf-8" data-turbolinks-track="reload"></script>
-<script src="<%= "#{rel_prefix}/js/highlight.pack.js" %>" type="text/javascript" charset="utf-8" data-turbolinks-track="reload"></script>
-<script src="<%= rel_prefix %>/js/turbolinks.js" type="text/javascript" charset="utf-8" data-turbolinks-track="reload"></script>
-<script src="<%= rel_prefix %>/js/search_index.js" type="text/javascript" charset="utf-8" data-turbolinks-track="reload"></script>
-<script src="<%= rel_prefix %>/js/searcher.js" type="text/javascript" charset="utf-8" data-turbolinks-track="reload"></script>
-<script src="<%= rel_prefix %>/panel/tree.js" type="text/javascript" charset="utf-8" data-turbolinks-track="reload"></script>
-<script src="<%= rel_prefix %>/js/searchdoc.js" type="text/javascript" charset="utf-8" data-turbolinks-track="reload"></script>
-
+<link rel="stylesheet" href="<%= rel_prefix %>/css/reset.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="<%= rel_prefix %>/css/panel.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="<%= rel_prefix %>/css/main.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="<%= rel_prefix %>/css/github.css" type="text/css" media="screen" />
+<script src="<%= rel_prefix %>/js/jquery-3.5.1.min.js" type="text/javascript" charset="utf-8"></script>
+<script src="<%= rel_prefix %>/js/main.js" type="text/javascript" charset="utf-8"></script>
+<script src="<%= rel_prefix %>/js/highlight.pack.js" type="text/javascript" charset="utf-8"></script>
+<script src="<%= rel_prefix %>/js/turbolinks.js" type="text/javascript" charset="utf-8"></script>
+<script src="<%= rel_prefix %>/js/search_index.js" type="text/javascript" charset="utf-8"></script>
+<script src="<%= rel_prefix %>/js/searcher.js" type="text/javascript" charset="utf-8"></script>
+<script src="<%= rel_prefix %>/panel/tree.js" type="text/javascript" charset="utf-8"></script>
+<script src="<%= rel_prefix %>/js/searchdoc.js" type="text/javascript" charset="utf-8"></script>
 <meta name="data-rel-prefix" content="<%= rel_prefix %>/">
 <meta name="data-tree-keys" content='<%= tree_keys %>'>

--- a/lib/rdoc/generator/template/rails/resources/js/main.js
+++ b/lib/rdoc/generator/template/rails/resources/js/main.js
@@ -31,7 +31,7 @@ document.addEventListener("turbolinks:load", function() {
   // Only initialize panel if not yet initialized
   if(!$('#panel .tree ul li').length) {
     $('#links').hide();
-    var panel = new Searchdoc.Panel($('#panel'), search_data, tree, $('meta[name="data-rel-prefix"]').attr("content"));
+    var panel = new Searchdoc.Panel($('#panel'), search_data, tree);
     var s = window.location.search.match(/\?q=([^&]+)/);
     if (s) {
       s = decodeURIComponent(s[1]).replace(/\+/g, ' ');

--- a/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
+++ b/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
@@ -135,11 +135,10 @@ function scrollIntoView(element, view) {
 
 // panel.js -----------------------------------------------
 
-Searchdoc.Panel = function(element, data, tree, prefix) {
+Searchdoc.Panel = function(element, data, tree) {
     this.$element = $(element);
     this.$input = $('input', element).eq(0);
     this.$result = $('.result ul', element).eq(0);
-    this.prefix = prefix;
     this.$current = null;
     this.$view = this.$result.parent();
     this.data = data;
@@ -232,12 +231,13 @@ Searchdoc.Panel.prototype = $.extend({}, Searchdoc.Navigation, new function() {
     };
 
     this.open = function(src) {
-        Turbolinks.visit(this.prefix + src);
+        var prefix = $('meta[name="data-rel-prefix"]').attr("content");
+        Turbolinks.visit(prefix + src);
         if (this.highlight) this.highlight(src);
     };
 
     this.select = function() {
-        this.open(this.$current.data('path'));
+        this.open(this.$current.attr('data-path'));
     };
 
     this.move = function(isDown) {
@@ -266,7 +266,7 @@ Searchdoc.Panel.prototype = $.extend({}, Searchdoc.Navigation, new function() {
         html += hlt(result.namespace) + '</p>';
         if (result.snippet) html += '<p class="snippet">' + stripHTML(result.snippet) + '</p>';
         li.innerHTML = html;
-        jQuery.data(li, 'path', result.path);
+        $(li).attr('data-path', result.path)
         return li;
     }
 


### PR DESCRIPTION
With the migration to a frameless layout, the URLs to assets were made
absolute instead of relative because of Turbolinks asset tracking.
But absolute URLs fail when we have multiple versions of the docs in
subdirectories like: https://api.rubyonrails.org/v6.1/
See: https://github.com/rails/rails/issues/44042

Turbolinks tracking requires absolute URLs
-------------------------------------------

Turbolinks does not consider relative URLs to assets identical when
tracking assets for reload, even if the absolute URL would be the same.
For example when visiting /index.html, in the following css link:

    <link rel="stylesheet" href="css/panel.css" type="text/css" data-turbolinks-track="reload" />

... the panel.css would not be seen as identical as when visiting
/classes/Array.html with the following css link:

    <link rel="stylesheet" href="../css/panel.css" type="text/css" data-turbolinks-track="reload" />

This results in page reloads as Turbolinks wants to make sure it has all
the latests assets loaded. With a page reload we lose the context of the
panel when using search.

Instead of using absolute URLs another solution would be to remove the
`data-turbolinks-track` attribute.

Removing the data-turbolinks-track attribute
---------------------------------------------

By removing the `data-turbolinks-track` attribute we can use relative
URLs again. In this case Turbolinks just reloads the assets everytime
we navigate to another page. Reloading assets has a small performance
cost, but this seems barely noticable. It also requires a change to search results.

Fixing the search results URLs
------------------------------

The search results are persisted across navigations using the
`data-turbolinks-permanent` attribute. When we no longer track the assets,
the search tree gets rebuild for every navigation. But the URLs to the
search results are no longer available in the panel DOM as these are
stored in jQuery data attributes.
jQuery does not persist this data when navigating to another page:

    The data- attributes are pulled in the first time the data property
    is accessed and then are no longer accessed or mutated (all data
    values are then stored internally in jQuery).

    https://api.jquery.com/data/#data1

By storing the path in a HTML data-attribute it starts working again.

Updating the rel_prefix
-----------------------

When we use relative URLs the rel_prefix will change when we navigate to
a page that is on another level. For example, navigating from
`/classes/ActiveRecord.html` to `/classes/ActiveRecord/Attributes/ClassMethods.html`
changes the prefix from `../` to `../../../`.
If the prefix can change on every navigation, the prefix needs to be
loaded from the meta tag everytime, instead of on the first
initialization only.