### PR TITLE
Don't use rdoc 6.4.0 for now

### DIFF
--- a/sdoc.gemspec
+++ b/sdoc.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = ["README.md"]
 
-  s.add_runtime_dependency("rdoc", ">= 5.0")
+  s.add_runtime_dependency("rdoc", ">= 5.0", "< 6.4.0")
 
   s.add_development_dependency("rack")
 


### PR DESCRIPTION
Rdoc 6.4.0 added psych 4.0 as a dependency.
This version of psych is not compatible with ruby 2.5 and lower
resulting in the following error:

     ArgumentError: wrong number of arguments (given 4, expected 1)
       /home/runner/work/sdoc/sdoc/vendor/bundle/ruby/2.5.0/gems/psych-4.0.3/lib/psych.rb:323:in `safe_load'

As we still support rubies lower that 2.5, we need to add a constraint.
Current Rails master also has rdoc locked to 6.3.3:

      https://github.com/rails/rails/blob/7ad7550601a19d94a4bb41b8c49e3bbc3c12b150/Gemfile.lock#L406

Also see: https://github.com/ruby/psych/issues/531#issuecomment-1003310234