### PR TITLE
Constrain psych version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ gem "rake"
 gem "minitest"
 gem "hoe"
 
+if RUBY_VERSION.to_f <= 2.5
+  gem "psych", "< 4.0"
+end
+
 if ENV["rdoc"] == "master"
   gem "rdoc", :github => "ruby/rdoc"
 end


### PR DESCRIPTION
`psych` version 4 is not compatible with ruby 2.5 and lower
resulting in the following error on CI:

    ArgumentError: wrong number of arguments (given 4, expected 1)
    /home/runner/work/sdoc/sdoc/vendor/bundle/ruby/2.5.0/gems/psych-4.0.3/lib/psych.rb:323:in `safe_load'

As we don't want to constrain psych in dependent application, the
contraint is added to the Gemfile instead of the gemspec.