### PR TITLE
Uninstall psych >= 4 gem for ruby 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,10 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
+      - name: Remove psych 4 for Ruby 2.5
+        if: matrix.ruby == '2.5'
+        run: gem uninstall psych -v '>=4.0'
+
       - name: Test
         run: |
           bundle exec rake


### PR DESCRIPTION
Ruby 2.5 doesn't work with psych >= 4