### PR TITLE
Bump bundler cache version on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          cache-version: 1
 
       - name: Test
         run: |

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,11 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "rack"
 gem "rake"
-gem "minitest"
 gem "hoe"
+gem "minitest"
+
 
 if RUBY_VERSION.to_f <= 2.5
   gem "psych", "< 4.0"

--- a/sdoc.gemspec
+++ b/sdoc.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("rdoc", ">= 5.0", "< 6.4.0")
 
-  s.add_development_dependency("rack")
-
   s.files         = `git ls-files`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 end


### PR DESCRIPTION
The current cache contains psych 4.0.3 which doesn't work for ruby 2.5.
The Gemfile has a conditional for the the psych version but this fails
because `bundle install` still fails because of the existence of psych
4.0.3
Adding the cache_version clears the corrupted cache.