### PR TITLE
Use window.location instead of Turbolinks.visit if protocol is 'file:'

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
+++ b/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
@@ -231,8 +231,12 @@ Searchdoc.Panel.prototype = $.extend({}, Searchdoc.Navigation, new function() {
     };
 
     this.open = function(src) {
-        var prefix = $('meta[name="data-rel-prefix"]').attr("content");
-        Turbolinks.visit(prefix + src);
+        var location = $('meta[name="data-rel-prefix"]').attr("content") + src;
+        if (window.location.protocol === "file:") {
+            window.location.href = location;
+        } else {
+            Turbolinks.visit(location);
+        }
         if (this.highlight) this.highlight(src);
     };
 


### PR DESCRIPTION
When opening the docs locally the side panel doesn't work because visits
with Turbolinks result in errors like:

      Uncaught DOMException: Failed to execute 'pushState' on 'History': A
      history state object with URL
      'file:///sdoc/doc/public/activerecord/README_rdoc.html'
      cannot be created in a document with origin 'null' and URL
      'file:///sdoc/doc/public/index.html'§

We can detect the protocol of the window and fallback to window.location to
open the URL. This will result in a full page load that will
lose state in the side panel, but it's better than navigation not
working.