### PR TITLE
Remove unsupported browser detection

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
+++ b/lib/rdoc/generator/template/rails/resources/js/searchdoc.js
@@ -89,7 +89,6 @@ Searchdoc.Navigation = new function() {
     };
 
     this.startMoveTimeout = function(isDown) {
-        if (!$.browser.mozilla && !$.browser.opera) return;
         if (this.moveTimeout) this.clearMoveTimeout();
         var _this = this;
 


### PR DESCRIPTION
When using keyboard shortcuts in the side panel the following error gets
thrown:

      Uncaught TypeError: $.browser is undefined
          startMoveTimeout https://api.rubyonrails.org/js/searchdoc.js:94
          onkeydown https://api.rubyonrails.org/js/searchdoc.js:57
          initNavigation https://api.rubyonrails.org/js/searchdoc.js:10
          ...

$.browser was deprecated in jQuery 1.3 and removed in 1.9; sdoc/rails
currently bundles jQuery 3.5.1. as noted by @dmke.

This browser detection is very old and no longer seems necessary in
modern browsers.

Fixes #173 