### PR TITLE
Add support for rdoc 6.4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+  pull_request:
+    branches: [ master ]
   schedule:
     - cron: '0 0 * * *'
 
@@ -31,7 +33,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          cache-version: 1
+          cache-version: 2
 
       - name: Test
         run: |

--- a/sdoc.gemspec
+++ b/sdoc.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = ["README.md"]
 
-  s.add_runtime_dependency("rdoc", ">= 5.0", "< 6.4.0")
+  s.add_runtime_dependency("rdoc", ">= 5.0")
 
   s.files         = `git ls-files`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
If the CI runs with older versions of ruby, there is no reason to pin
the rdoc version.
This also changes the github actions tests to run on PRs.