### PR TITLE
Allow setting CSS based version badge

### DIFF
--- a/lib/rdoc/generator/template/rails/class.rhtml
+++ b/lib/rdoc/generator/template/rails/class.rhtml
@@ -45,6 +45,9 @@
             <li><a href="<%= "#{rel_prefix}/#{h file.path}" %>"><%= h file.absolute_name %></a></li>
             <% end  %>
         </ul>
+        <% if ENV['HORO_BADGE_VERSION'] %>
+            <div id="version-badge"><%= ENV['HORO_BADGE_VERSION'] %></div>
+        <% end %>
     </div>
 
     <main id="bodyContent">

--- a/lib/rdoc/generator/template/rails/file.rhtml
+++ b/lib/rdoc/generator/template/rails/file.rhtml
@@ -32,6 +32,9 @@
             </li>
             <li>Last modified: <%= file.file_stat.mtime %></li>
         </ul>
+        <% if ENV['HORO_BADGE_VERSION'] %>
+            <div id="version-badge"><%= ENV['HORO_BADGE_VERSION'] %></div>
+        <% end %>
     </div>
 
     <main id="bodyContent">

--- a/lib/rdoc/generator/template/rails/index.rhtml
+++ b/lib/rdoc/generator/template/rails/index.rhtml
@@ -24,6 +24,9 @@
             <li><%= h index.relative_name %></li>
             <li>Last modified: <%= index.last_modified %></li>
         </ul>
+        <% if ENV['HORO_BADGE_VERSION'] %>
+            <div id="version-badge"><%= ENV['HORO_BADGE_VERSION'] %></div>
+        <% end %>
     </div>
 
     <main id="bodyContent">

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -403,3 +403,22 @@ p code {
   background: #fff;
   font-size: 2rem;
 }
+
+#version-badge {
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 100;
+  color: white;
+  transform: rotate(45deg) translate(27.5%, -40%);
+  min-width: 200px;
+  font-family: Helvetica, Arial, sans-serif;
+  font-size: 30px;
+  font-weight: bold;
+  font-style: italic;
+  line-height: 1.5;
+  text-shadow: 2px 2px 4px #5400007d;
+  text-align: center;
+  box-shadow: 0px 2px 2px 1px #1209096e;
+  background: radial-gradient(circle, rgb(255, 10, 0) 0%, rgb(200, 0, 0) 90%);
+}

--- a/lib/rdoc/generator/template/rails/resources/css/panel.css
+++ b/lib/rdoc/generator/template/rails/resources/css/panel.css
@@ -12,8 +12,7 @@
             top: 0;
             background: #000;
             color: #fff;
-            padding-right: 10px;
-            text-align: right;
+            padding: 0 10px;
             line-height: 40px;
             cursor: pointer;
             z-index: 2;
@@ -84,7 +83,7 @@
         width: 300px;
         height: 100%;
         background: #FFF;
-        z-index: 10;
+        z-index: 200;
         font-family: "Helvetica Neue", "Arial", sans-serif;
         overflow-x: hidden;
         border-right: 1px #ccc solid;


### PR DESCRIPTION
Currently the Rails API documentation inserts a HTML fragment containing
an image to add the Edge badge:
https://github.com/rails/rails-docs-server/blob/c8ca05fc9e434618a8e74b805c5b3fb94cf83caa/lib/generators/main.rb#L29-L45

Instead we can reuse the CSS-based Guides badge.
This also allows us to add the badge for stable versions, just like we
do for the guides.
The badge will only be shown when passing in the HORO_BADGE_VERSION env
variable.

<img width="766" alt="image" src="https://user-images.githubusercontent.com/28561/166525497-136810f5-579e-4837-9093-9767d046c84c.png">
<img width="428" alt="image" src="https://user-images.githubusercontent.com/28561/166525546-6c6f2ec2-0907-491d-a756-91dc87d3cb1a.png">
