### PR TITLE
Use latest Bundler to fix jruby build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby:
@@ -32,6 +32,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: latest
           bundler-cache: true
           cache-version: 2
 


### PR DESCRIPTION
Should fix the following error:

    Run bundle exec rake
    bundler: failed to load command: rake (/home/runner/work/sdoc/sdoc/vendor/bundle/jruby/3.1.0/bin/rake)
    Gem::LoadError: You have already activated jar-dependencies 0.4.1, but your Gemfile requires jar-dependencies 0.4.2. Since jar-dependencies is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports jar-dependencies as a default gem.

Fix is similar to:
  https://github.com/sparklemotion/nokogiri/pull/2618