### PR TITLE
`index_path` should handle a nil `main_page`

### DIFF
--- a/lib/sdoc/generator.rb
+++ b/lib/sdoc/generator.rb
@@ -194,7 +194,7 @@ class RDoc::Generator::SDoc
   ### Determines index path based on @options.main_page (or lack thereof)
   def index_path
     # Transform class name to file path
-    if @options.main_page.include?("::")
+    if @options.main_page&.include?("::")
       slashed = @options.main_page.sub(/^::/, "").gsub("::", "/")
       "%s/%s.html" % [ class_dir, slashed ]
     else


### PR DESCRIPTION
It seems like it is okay if `main_page` is nil, see line 209. Given that, I just made line 197 not crash if it is nil.