### PR TITLE
Add css class for constant and keymethods

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/github.css
+++ b/lib/rdoc/generator/template/rails/resources/css/github.css
@@ -72,7 +72,8 @@ pre .regexp {
   color: #009926
 }
 
-pre .class {
+pre .class,
+pre .constant {
   color: #458;
   font-weight: bold
 }


### PR DESCRIPTION
Constants and keymethods have their own css class, but these are currently missing in the css.

## Before
<img width="352" alt="image" src="https://user-images.githubusercontent.com/28561/207614599-328e72ed-5cf4-4182-97d6-0324b47f154a.png">

## After
<img width="371" alt="image" src="https://user-images.githubusercontent.com/28561/207616206-f47fa60c-a174-4e8c-b124-176d2fdac46e.png">

