### PR TITLE
Add padding and rounded borders to code examples

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -262,8 +262,9 @@ tt {
 }
 
 .description pre {
-  padding: 0.5em;
+  padding: 1em 1.2em;
   background: #EEEEEE;
+  border-radius: 10px;
   font-size: 15px;
   overflow-x: scroll;
 }


### PR DESCRIPTION
Make code examples a bit more friendly looking by rounding the borders and adding some padding.

## Before
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/28561/207617710-4f35f939-cc47-4f91-84af-47987ad7e44b.png">

## After
This also uses #191
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/28561/207617758-48552889-0d51-4a02-ac90-b53d040cbbf1.png">
