### PR TITLE
`File.exists?` has been removed as of Ruby 3.2.0

### DIFF
--- a/lib/sdoc/github.rb
+++ b/lib/sdoc/github.rb
@@ -50,7 +50,7 @@ module SDoc::GitHub
 
   def path_to_git_dir(path)
     while !path.empty? && path != '.'
-      if (File.exists? File.join(path, '.git'))
+      if (File.exist? File.join(path, '.git'))
         return path
       end
       path = File.dirname(path)

--- a/lib/sdoc/merge.rb
+++ b/lib/sdoc/merge.rb
@@ -168,7 +168,7 @@ class SDoc::Merge
   end
 
   def setup_output_dir
-    if File.exists? @op_dir
+    if File.exist? @op_dir
       error "#{@op_dir} already exists"
     end
     FileUtils.mkdir_p @op_dir
@@ -176,9 +176,9 @@ class SDoc::Merge
 
   def check_directories
     @directories.each do |dir|
-      unless File.exists?(File.join(dir, FLAG_FILE)) &&
-      File.exists?(File.join(dir, RDoc::Generator::SDoc::TREE_FILE)) &&
-      File.exists?(File.join(dir, RDoc::Generator::SDoc::SEARCH_INDEX_FILE))
+      unless File.exist?(File.join(dir, FLAG_FILE)) &&
+      File.exist?(File.join(dir, RDoc::Generator::SDoc::TREE_FILE)) &&
+      File.exist?(File.join(dir, RDoc::Generator::SDoc::SEARCH_INDEX_FILE))
         error "#{dir} does not seem to be an sdoc directory"
       end
     end


### PR DESCRIPTION
Encountered NoMethodError rather surprisingly during my attempt to run rdoc task for rails/rails with 3.2.0.

Turns out `File.exists?` has been removed as of Ruby 3.2.0: https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2

Hence runnig sdoc with 3.2.0 inevitably fails. Let's start to use `File.exist?` instead, shall we?