### PR TITLE
Don't justify paragraphs

### DIFF
--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -33,7 +33,6 @@ h1 a, h2 a, .banner a {
 
 p {
   margin-bottom: 1em;
-  text-align: justify;
 }
 
 h1 {


### PR DESCRIPTION
![Screenshot 2023-02-06 at 16 38 10](https://user-images.githubusercontent.com/277819/216913091-7cf1af86-ef5d-40b3-a283-2269d45d7a9e.png)

The behavior of this is weird, as far as I can tell it only justifies paragraphs which have other content, like code or links within them. otherwise it's perfectly fine leaving a paragraph to the current length. Compare these two sentences above.

There are many places in the Rails API docs that are affected by this, so I think it's just easier to remove the CSS rule here.