### PR TITLE
Move permalink out of method heading

### DIFF
--- a/lib/rdoc/generator/template/rails/_context.rhtml
+++ b/lib/rdoc/generator/template/rails/_context.rhtml
@@ -154,8 +154,8 @@
             <% else %>
               <b><%= h method.name %></b><%= h method.params %>
             <% end %>
-            <a href="<%= "#{rel_prefix}/#{context.path}##{method.aref}"%>" name="<%= method.aref %>" class="permalink">Link</a>
           </h3>
+          <a href="<%= "#{rel_prefix}/#{context.path}##{method.aref}"%>" name="<%= method.aref %>" class="permalink">Link</a>
 
           <% if method.comment %>
             <div class="description">

--- a/lib/rdoc/generator/template/rails/resources/css/main.css
+++ b/lib/rdoc/generator/template/rails/resources/css/main.css
@@ -270,6 +270,7 @@ tt {
 
 .method {
     margin-bottom: 2em;
+    position: relative;
 }
 .method .description,
 .method .sourcecode
@@ -293,10 +294,11 @@ tt {
     position: relative;
 }
 
-.method .method-title a.permalink {
+.method a.permalink {
   position: absolute;
-  font-size: 0.75em;
+  font-size: 0.9em;
   right: 0;
+  top: 0;
 }
 
 .method .sourcecode p.source-link {


### PR DESCRIPTION
Currently every method heading includes the text "Link" for the permalink of the method. By removing this outside of the heading we should improve the SEO for these methods.

An alternative could be to make the method itself the permalink.